### PR TITLE
Problem with {{og}} and redirects

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -34,7 +34,7 @@ Twinkle.block = function twinkleblock() {
 };
 
 Twinkle.block.callback = function twinkleblockCallback() {
-	if (relevantUserName === 'Bas dehaan'){ //don't fight me with my own weapon - first of two easter eggs
+	if (relevantUserName === 'Bas dehaan'){ //don't fight me with my own weapon
 		alert('Uw zoekopdracht \"Blokkeer Bas_dehaan\" gaf geen resultaten. Bedoelde u \"WP:DESYSOP#' + mw.config.get('wgUserName') + '\"?');
 		return;
 	}
@@ -51,7 +51,6 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	Twinkle.block.field_block_options = {};
 	Twinkle.block.field_template_options = {};
 	
-	//Prepare the interface for the blocking sysop
 	var Window = new Morebits.simpleWindow(650, 530);
 	// need to be verbose about who we're blocking
 	Window.setTitle('Blokkeer of plaats blokkeersjabloon op ' + relevantUserName);
@@ -68,7 +67,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 		type: 'field',
 		label: 'Uit te voeren handelingen'
 	});
-	actionfield.append({ //Define the relevant actions and options for the sysop
+	actionfield.append({
 		type: 'checkbox',
 		name: 'actiontype',
 		event: Twinkle.block.callback.change_action,
@@ -861,7 +860,7 @@ Twinkle.block.blockPresetsInfo = {
 		disabletalk: true,
 		noemail: true,
 		templateName: 'blok',
-		reason: '[[Wikipedia:LSV|Langdurig structureel vandalisme]] (LTA)', //Adding 'LTA' as an internationally approved abbreviation
+		reason: '[[Wikipedia:LSV|Langdurig structureel vandalisme]] (LTA)',
 		summary: 'Je bent voor onbepaalde tijd geblokkeerd wegens [[Wikipedia:LSV|Langdurig structureel vandalisme]]',
 		suppressArticleInSummary: true
 	},
@@ -1007,7 +1006,7 @@ Twinkle.block.blockGroups = [
 		list: [
 			{ label: 'Herhaald vandalisme', value: 'vandalisme' },
 			{ label: 'Ingelogde vandaal', value: 'ingelogde vandaal' },
-			{ label: 'Langdurig structureel vandalisme (LTA)', value: 'lta' }, //Adding LTA as common abbreviation
+			{ label: 'Langdurig structureel vandalisme (LTA)', value: 'lta' },
 			{ label: 'Ongewenste gebruikersnaam', value: 'og' },
 			{ label: 'Ongewenste gebruikersnaam - bedrijf', value: 'ogbedrijf' },
 			{ label: 'Afkoelblok (informeel)', value: 'douche' },
@@ -1219,7 +1218,6 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemplate(e) {
 	var form = e.target.form, value = form.template.value, settings = Twinkle.block.blockPresetsInfo[value];
 	
-	//Load the different settings of the checkboxes set by the sysop
 	var blockBox = $(form).find('[name=actiontype][value=block]').is(':checked');
 	var partialBox = $(form).find('[name=actiontype][value=partial]').is(':checked');
 	var templateBox = $(form).find('[name=actiontype][value=template]').is(':checked');
@@ -1321,7 +1319,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 	templateoptions.expiry = templateoptions.template_expiry || blockoptions.expiry;
 
 	if (toBlock) {
-		if (blockoptions.partial) {//Check some easily made errors with partial blocks
+		if (blockoptions.partial) {
 			if (blockoptions.disabletalk && blockoptions.namespacerestrictions.indexOf('3') === -1) {
 				return alert('Deelblokkades kunnen de overlegpagina niet blokkeren, tenzij de \'Overleg gebruiker\' naamruimte ook geblokkeerd wordt!');
 			}
@@ -1334,7 +1332,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 		if (!blockoptions.expiry) {
 			return alert('Geef een blokkadeduur!');
 		} else if (Morebits.string.isInfinity(blockoptions.expiry) && !Twinkle.block.isRegistered) {
-			return alert("Een IP-adres kan niet voor onbepaalde tijd geblokkeerd worden!"); //It is sometimes done, but not good practice
+			return alert("Een IP-adres kan niet voor onbepaalde tijd geblokkeerd worden!");
 		}
 		if (!blockoptions.reason) {
 			return alert('Geef een rede voor de blokkade!');
@@ -1477,19 +1475,18 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 	wikipedia_page.load(Twinkle.block.callback.main);
 };
 
-//Prepare the text that will be dropped onto the wiki
 Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 	var text = '\n{{', settings = Twinkle.block.blockPresetsInfo[params.template];
 	if (!settings.nonstandard) {
-		if (params.template === 'ogbedrijf') { //Catch a specific exception that might occur when a company gets blocked
+		if (params.template === 'ogbedrijf') {
 			text += 'subst:';
 		}
-		if (params.template === 'og') { //A very specific case for inappropriate usernames
-			text += '{{bog}}\nsubst:'; //Add the bog-template, and substitute what comes next
+		if (params.template === 'og') {
+			text += 'bog}}\n{{';
 		}
-		text += params.template; //Add the name of the template to the message that is being prepared
-		if (params.template === 'og') { //Catch a specific problem with blocking someone with an undesired username - due to the OG-template
-			text += '|naam={{subst:PAGENAME}}'; //Add the bog-template, and substitute what comes next
+		text += params.template;
+		if (params.template === 'og') {
+			text += '|naam={{subst:PAGENAME}}';
 		}
 		if (params.article && settings.pageParam) {
 			text += '|pagina=' + params.article;
@@ -1603,7 +1600,7 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 
 	params.expiry = typeof params.template_expiry !== 'undefined' ? params.template_expiry : params.expiry;
 
-	text += Twinkle.block.callback.getBlockNoticeWikitext(params); //Calls the function that generates the block message for the user's talk page
+	text += Twinkle.block.callback.getBlockNoticeWikitext(params);
 
 	// build the edit summary
 	var summary = messageData.summary;

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -50,7 +50,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	Twinkle.block.currentBlockInfo = undefined;
 	Twinkle.block.field_block_options = {};
 	Twinkle.block.field_template_options = {};
-	
+
 	var Window = new Morebits.simpleWindow(650, 530);
 	// need to be verbose about who we're blocking
 	Window.setTitle('Blokkeer of plaats blokkeersjabloon op ' + relevantUserName);

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1217,7 +1217,7 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 
 Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemplate(e) {
 	var form = e.target.form, value = form.template.value, settings = Twinkle.block.blockPresetsInfo[value];
-	
+
 	var blockBox = $(form).find('[name=actiontype][value=block]').is(':checked');
 	var partialBox = $(form).find('[name=actiontype][value=partial]').is(':checked');
 	var templateBox = $(form).find('[name=actiontype][value=template]').is(':checked');

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1472,7 +1472,7 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 	Morebits.wiki.actionCompleted.notice = 'Handelingen voltooid, overlegpagina wordt geladen...';
 
 	var wikipedia_page = new Morebits.wiki.page(userTalkPage, 'Overlegpagina bewerken');
-	wikipedia_page.setFollowRedirect(true, false); //Make sure that the template gets placed on the page for the whole range
+	wikipedia_page.setFollowRedirect(true);
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.block.callback.main);
 };

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1472,6 +1472,7 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 	Morebits.wiki.actionCompleted.notice = 'Handelingen voltooid, overlegpagina wordt geladen...';
 
 	var wikipedia_page = new Morebits.wiki.page(userTalkPage, 'Overlegpagina bewerken');
+	wikipedia_page.setFollowRedirect(true, false); //Make sure that the template gets placed on the page for the whole range
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.block.callback.main);
 };

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -34,7 +34,7 @@ Twinkle.block = function twinkleblock() {
 };
 
 Twinkle.block.callback = function twinkleblockCallback() {
-	if (relevantUserName === 'Bas dehaan'){ //don't fight me with my own weapon
+	if (relevantUserName === 'Bas dehaan'){ //don't fight me with my own weapon - first of two easter eggs
 		alert('Uw zoekopdracht \"Blokkeer Bas_dehaan\" gaf geen resultaten. Bedoelde u \"WP:DESYSOP#' + mw.config.get('wgUserName') + '\"?');
 		return;
 	}
@@ -50,7 +50,8 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	Twinkle.block.currentBlockInfo = undefined;
 	Twinkle.block.field_block_options = {};
 	Twinkle.block.field_template_options = {};
-
+	
+	//Prepare the interface for the blocking sysop
 	var Window = new Morebits.simpleWindow(650, 530);
 	// need to be verbose about who we're blocking
 	Window.setTitle('Blokkeer of plaats blokkeersjabloon op ' + relevantUserName);
@@ -67,7 +68,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 		type: 'field',
 		label: 'Uit te voeren handelingen'
 	});
-	actionfield.append({
+	actionfield.append({ //Define the relevant actions and options for the sysop
 		type: 'checkbox',
 		name: 'actiontype',
 		event: Twinkle.block.callback.change_action,
@@ -860,7 +861,7 @@ Twinkle.block.blockPresetsInfo = {
 		disabletalk: true,
 		noemail: true,
 		templateName: 'blok',
-		reason: '[[Wikipedia:LSV|Langdurig structureel vandalisme]]',
+		reason: '[[Wikipedia:LSV|Langdurig structureel vandalisme]] (LTA)', //Adding 'LTA' as an internationally approved abbreviation
 		summary: 'Je bent voor onbepaalde tijd geblokkeerd wegens [[Wikipedia:LSV|Langdurig structureel vandalisme]]',
 		suppressArticleInSummary: true
 	},
@@ -1006,7 +1007,7 @@ Twinkle.block.blockGroups = [
 		list: [
 			{ label: 'Herhaald vandalisme', value: 'vandalisme' },
 			{ label: 'Ingelogde vandaal', value: 'ingelogde vandaal' },
-			{ label: 'Langdurig structureel vandalisme', value: 'lta' },
+			{ label: 'Langdurig structureel vandalisme (LTA)', value: 'lta' }, //Adding LTA as common abbreviation
 			{ label: 'Ongewenste gebruikersnaam', value: 'og' },
 			{ label: 'Ongewenste gebruikersnaam - bedrijf', value: 'ogbedrijf' },
 			{ label: 'Afkoelblok (informeel)', value: 'douche' },
@@ -1217,7 +1218,8 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 
 Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemplate(e) {
 	var form = e.target.form, value = form.template.value, settings = Twinkle.block.blockPresetsInfo[value];
-
+	
+	//Load the different settings of the checkboxes set by the sysop
 	var blockBox = $(form).find('[name=actiontype][value=block]').is(':checked');
 	var partialBox = $(form).find('[name=actiontype][value=partial]').is(':checked');
 	var templateBox = $(form).find('[name=actiontype][value=template]').is(':checked');
@@ -1319,7 +1321,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 	templateoptions.expiry = templateoptions.template_expiry || blockoptions.expiry;
 
 	if (toBlock) {
-		if (blockoptions.partial) {
+		if (blockoptions.partial) {//Check some easily made errors with partial blocks
 			if (blockoptions.disabletalk && blockoptions.namespacerestrictions.indexOf('3') === -1) {
 				return alert('Deelblokkades kunnen de overlegpagina niet blokkeren, tenzij de \'Overleg gebruiker\' naamruimte ook geblokkeerd wordt!');
 			}
@@ -1332,7 +1334,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 		if (!blockoptions.expiry) {
 			return alert('Geef een blokkadeduur!');
 		} else if (Morebits.string.isInfinity(blockoptions.expiry) && !Twinkle.block.isRegistered) {
-			return alert("Een IP-adres kan niet voor onbepaalde tijd geblokkeerd worden!");
+			return alert("Een IP-adres kan niet voor onbepaalde tijd geblokkeerd worden!"); //It is sometimes done, but not good practice
 		}
 		if (!blockoptions.reason) {
 			return alert('Geef een rede voor de blokkade!');
@@ -1474,13 +1476,14 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 	wikipedia_page.load(Twinkle.block.callback.main);
 };
 
+//Prepare the text that will be dropped onto the wiki
 Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 	var text = '\n{{', settings = Twinkle.block.blockPresetsInfo[params.template];
 	if (!settings.nonstandard) {
-		if (params.template === 'ogbedrijf') {
+		if (params.template === 'ogbedrijf') { //Catch a specific exception that might occur when a company gets blocked
 			text += 'subst:';
 		}
-		text += params.template;
+		text += params.template; //Add the name of the template to the message that is being prepared
 		if (params.article && settings.pageParam) {
 			text += '|pagina=' + params.article;
 		}

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1483,7 +1483,13 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 		if (params.template === 'ogbedrijf') { //Catch a specific exception that might occur when a company gets blocked
 			text += 'subst:';
 		}
+		if (params.template === 'og') { //A very specific case for inappropriate usernames
+			text += '{{bog}}\nsubst:'; //Add the bog-template, and substitute what comes next
+		}
 		text += params.template; //Add the name of the template to the message that is being prepared
+		if (params.template === 'og') { //Catch a specific problem with blocking someone with an undesired username - due to the OG-template
+			text += '|naam={{subst:PAGENAME}}'; //Add the bog-template, and substitute what comes next
+		}
 		if (params.article && settings.pageParam) {
 			text += '|pagina=' + params.article;
 		}

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1602,7 +1602,7 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 
 	params.expiry = typeof params.template_expiry !== 'undefined' ? params.template_expiry : params.expiry;
 
-	text += Twinkle.block.callback.getBlockNoticeWikitext(params);
+	text += Twinkle.block.callback.getBlockNoticeWikitext(params); //Calls the function that generates the block message for the user's talk page
 
 	// build the edit summary
 	var summary = messageData.summary;


### PR DESCRIPTION
Fixing an issue when a block was used with the 'og'-template.
Adding support for talk pages that are redirects to a page corresponding to some larger range.
At various places, adding comments to explain the code more clearly (and why certain choices are made).